### PR TITLE
Make partitionStartIndicies of ShuffleQSInput immutable

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -103,7 +103,10 @@ abstract class QueryStage extends UnaryExecNode {
 
       val partitionStartIndices =
         exchangeCoordinator.estimatePartitionStartIndices(childMapOutputStatistics)
-      queryStageInputs.foreach(_.partitionStartIndices = Some(partitionStartIndices))
+      child = child.transform {
+        case ShuffleQueryStageInput(childStage, output, _) =>
+          ShuffleQueryStageInput(childStage, output, Some(partitionStartIndices))
+      }
     }
 
     // 3. Codegen and update the UI

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -75,7 +75,7 @@ abstract class QueryStageInput extends LeafExecNode {
 case class ShuffleQueryStageInput(
     childStage: ShuffleQueryStage,
     override val output: Seq[Attribute],
-    var partitionStartIndices: Option[Array[Int]] = None)
+    partitionStartIndices: Option[Array[Int]] = None)
   extends QueryStageInput {
 
   override def outputPartitioning: Partitioning = partitionStartIndices.map {


### PR DESCRIPTION
## What changes were proposed in this pull request?

We think it's not a good design to make `partitionStartIndices` mutable. In short, the state of mutable value may bring problems.

In the previous mutable implementation, think about this condition: if in a rule we change `partitionStartIndices`, then we find it's better not to change that, and we revert that. If we don't record `partitionStartIndices` at the beginning of this rule, the revert might not be correct.

## How was this patch tested?

Existing UT.
